### PR TITLE
checking autoscaling to false. due to error

### DIFF
--- a/charts/common/templates/hpa.yaml
+++ b/charts/common/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "generic.fullname" . }}

--- a/examples/common-backend-autoscaling/values-override.yaml
+++ b/examples/common-backend-autoscaling/values-override.yaml
@@ -1,6 +1,6 @@
 # See ../../charts/common/values.yaml for full list of features
 autoscaling:
-  enabled: false
+  enabled: true
   targetCPUUtilizationPercentage: 80
 
 replicaCount: "2"

--- a/examples/common-backend-autoscaling/values-override.yaml
+++ b/examples/common-backend-autoscaling/values-override.yaml
@@ -1,6 +1,6 @@
 # See ../../charts/common/values.yaml for full list of features
 autoscaling:
-  enabled: true
+  enabled: false
   targetCPUUtilizationPercentage: 80
 
 replicaCount: "2"

--- a/examples/common-backend-autoscaling/values-override.yaml
+++ b/examples/common-backend-autoscaling/values-override.yaml
@@ -6,8 +6,8 @@ autoscaling:
 replicaCount: "2"
 
 image:
-  registry: 12345.dkr.ecr.eu-west-2.amazonaws.com
-  repository: app2
+  registry: docker.io
+  repository: nginx
   tag: "484309960e4294189d5a1253924fa29e8ad8dba6-prod"
   pullPolicy: "Always"
 

--- a/examples/common-complete/values-override.yaml
+++ b/examples/common-complete/values-override.yaml
@@ -3,7 +3,7 @@
 replicaCount: 2
 
 autoscaling:
-  enabled: false
+  enabled: true
   targetCPUUtilizationPercentage: 80
 
 

--- a/examples/common-complete/values-override.yaml
+++ b/examples/common-complete/values-override.yaml
@@ -3,7 +3,7 @@
 replicaCount: 2
 
 autoscaling:
-  enabled: true
+  enabled: false
   targetCPUUtilizationPercentage: 80
 
 

--- a/examples/common-complete/values-override.yaml
+++ b/examples/common-complete/values-override.yaml
@@ -48,7 +48,7 @@ initContainers:
 hook:
   enabled: true
   image:
-    repository: "my/helm-db-tools"
+    repository: ngine:latest
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: "1.0.0"

--- a/examples/common-node-express/values-override.yaml
+++ b/examples/common-node-express/values-override.yaml
@@ -5,7 +5,7 @@ replicaCount: 6
 image: 
   registry: docker.io
   repository: nginx
-  tag: "prd-latest"
+  tag: "latest"
   pullPolicy: "Always"
 
 serviceAccount:

--- a/examples/common-node-express/values-override.yaml
+++ b/examples/common-node-express/values-override.yaml
@@ -3,8 +3,8 @@
 replicaCount: 6
 
 image: 
-  registry: 12345.dkr.ecr.eu-west-2.amazonaws.com
-  repository: app1
+  registry: docker.io
+  repository: nginx
   tag: "prd-latest"
   pullPolicy: "Always"
 

--- a/examples/common-orleans/values-override.yaml
+++ b/examples/common-orleans/values-override.yaml
@@ -5,7 +5,7 @@ replicaCount: 6
 image: 
   registry: docker.io
   repository: nginx
-  tag: "prd-latest"
+  tag: "latest"
   pullPolicy: "Always"
 
 serviceAccount:

--- a/examples/common-orleans/values-override.yaml
+++ b/examples/common-orleans/values-override.yaml
@@ -3,8 +3,8 @@
 replicaCount: 6
 
 image: 
-  registry: 12345.dkr.ecr.eu-west-2.amazonaws.com
-  repository: app1
+  registry: docker.io
+  repository: nginx
   tag: "prd-latest"
   pullPolicy: "Always"
 


### PR DESCRIPTION
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /home/hitesh/.kube/config_kind
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /home/hitesh/.kube/config_kind
Release "myrelease" does not exist. Installing it now.
coalesce.go:237: warning: skipped value for app.env: Not a table.
Error: unable to build kubernetes objects from release manifest: resource mapping not found for name: "myrelease-app" namespace: "default" from "": no matches for kind "HorizontalPodAutoscaler" in version "autoscaling/v2beta1"
ensure CRDs are installed first


the error from cmd